### PR TITLE
refactor: forward ref in Button component

### DIFF
--- a/components/ui/button.jsx
+++ b/components/ui/button.jsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva } from "class-variance-authority";
@@ -35,21 +37,20 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}) {
-  const Comp = asChild ? Slot : "button"
+const Button = React.forwardRef(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
 
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props} />
-  );
-}
+    return (
+      <Comp
+        ref={ref}
+        data-slot="button"
+        className={cn(buttonVariants({ variant, size, className }))}
+        {...props} />
+    )
+  }
+)
+
+Button.displayName = "Button"
 
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- add `'use client'` directive to button component
- refactor Button to `React.forwardRef` for proper prop and ref forwarding

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc7d937330832b8ee701fa57342e7c